### PR TITLE
VariableFileLineIteratorのバグ修正

### DIFF
--- a/terasoluna-filedao/src/main/java/jp/terasoluna/fw/file/dao/standard/VariableFileLineIterator.java
+++ b/terasoluna-filedao/src/main/java/jp/terasoluna/fw/file/dao/standard/VariableFileLineIterator.java
@@ -222,7 +222,7 @@ public class VariableFileLineIterator<T> extends AbstractFileLineIterator<T> {
         char[] columnEncloseChar = getColumnEncloseChar();
 
         if (!isEnclosed()) {
-            return StringUtils.split(fileLineString, Character.toString(delimiter));
+            return StringUtils.splitByWholeSeparator(fileLineString, Character.toString(delimiter));
         } else {
             for (char currentChar : fileLineString.toCharArray()) {
                 if (previousChar == Character.MIN_VALUE) {

--- a/terasoluna-filedao/src/main/java/jp/terasoluna/fw/file/dao/standard/VariableFileLineIterator.java
+++ b/terasoluna-filedao/src/main/java/jp/terasoluna/fw/file/dao/standard/VariableFileLineIterator.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import jp.terasoluna.fw.file.annotation.FileFormat;
 import jp.terasoluna.fw.file.dao.FileException;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * 可変長ファイルファイル用のファイルアクセス(データ取得)クラス。
  * <p>
@@ -220,7 +222,7 @@ public class VariableFileLineIterator<T> extends AbstractFileLineIterator<T> {
         char[] columnEncloseChar = getColumnEncloseChar();
 
         if (!isEnclosed()) {
-            return fileLineString.split(Character.toString(delimiter), -1);
+            return StringUtils.split(fileLineString, Character.toString(delimiter));
         } else {
             for (char currentChar : fileLineString.toCharArray()) {
                 if (previousChar == Character.MIN_VALUE) {


### PR DESCRIPTION
可変長ファイルの区切り文字は「|」の場合、バッグがあります。
